### PR TITLE
[ FE ] - 닉네임 페이지 비지니스 로직, UI 분리

### DIFF
--- a/packages/client/src/pages/nickname/hooks/useNicknameSubmit.ts
+++ b/packages/client/src/pages/nickname/hooks/useNicknameSubmit.ts
@@ -1,0 +1,41 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { setCookie } from '@/shared/utils/cookie';
+import { getQuizSocket } from '@/shared/utils/socket';
+import { emitEventWithAck } from '@/shared/utils/emitEventWithAck';
+import { toastController } from '@/features/toast/model/toastController';
+
+export const useNicknameSubmit = () => {
+  const { pinCode } = useParams();
+  const navigate = useNavigate();
+  const toast = toastController();
+
+  const handleSubmit = async (nickname: string) => {
+    if (!pinCode) {
+      toast.error('잘못된 접근입니다.');
+      navigate('/');
+      return;
+    }
+
+    const socket = getQuizSocket();
+    try {
+      const sid = await emitEventWithAck<string>(socket, 'session', {
+        pinCode,
+        nickname,
+      });
+
+      if (!sid) {
+        toast.warning('방이 가득 찼습니다.');
+        navigate('/');
+        return;
+      }
+
+      setCookie('sid', sid, 30);
+      socket.emit('participant notice', { pinCode });
+      navigate(`/quiz/wait/${pinCode}`);
+    } catch (error) {
+      toast.error('닉네임 등록 중 문제가 발생했습니다.');
+    }
+  };
+
+  return handleSubmit;
+};

--- a/packages/client/src/pages/nickname/index.tsx
+++ b/packages/client/src/pages/nickname/index.tsx
@@ -1,78 +1,23 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { NicknameForm } from './ui/NicknameForm';
+import { useNicknameSubmit } from './hooks/useNicknameSubmit';
 
-import TrophyIcon from '@/shared/assets/icons/tropyhy.svg?react';
-import AvatarIcon from '@/shared/assets/icons/avatar.svg?react';
+export default function NicknamePage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleNicknameSubmit = useNicknameSubmit();
 
-import { setCookie } from '@/shared/utils/cookie';
-import { getQuizSocket } from '@/shared/utils/socket';
-import { emitEventWithAck } from '@/shared/utils/emitEventWithAck';
-import { toastController } from '@/features/toast/model/toastController';
-
-const MAX_NICKNAME_LENGTH = 12;
-
-export default function Nickname() {
-  const { pinCode } = useParams();
-  const navigate = useNavigate();
-  const toast = toastController();
-  const [nickname, setNickname] = useState('');
-
-  const handleNicknameSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const socket = getQuizSocket();
+  const handleSubmit = async (nickname: string) => {
+    setIsSubmitting(true);
     try {
-      const sid = await emitEventWithAck<string>(socket, 'session', {
-        pinCode: pinCode,
-        nickname: nickname,
-      });
-      if (!sid) {
-        toast.warning('방이 가득 찼습니다.');
-        navigate(`/`);
-        return;
-      }
-      setCookie('sid', sid, 30);
-      socket.emit('participant notice', { pinCode: pinCode });
-      navigate(`/quiz/wait/${pinCode}`);
-    } catch (error) {
-      toast.error('닉네임 등록 중 문제가 발생했습니다.');
+      await handleNicknameSubmit(nickname);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
     <div className="flex flex-col items-center px-64 pt-16 min-w-[980px]">
-      <form className="flex flex-col items-center gap-3 w-fit" onSubmit={handleNicknameSubmit}>
-        <label
-          htmlFor="nickname"
-          className="flex gap-2 ml-1 items-center text-xl font-bold self-start"
-        >
-          <TrophyIcon />
-          닉네임
-        </label>
-        <div className="flex gap-3 items-center w-[650px] h-16 p-4 border-2 rounded-base border-border">
-          <div className="flex justify-center items-center w-8 h-8 rounded-full bg-weak">
-            <AvatarIcon />
-          </div>
-          <input
-            type="text"
-            id="nickname"
-            placeholder="Your Name"
-            className="w-[488px] bg-transparent focus:outline-none"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            maxLength={MAX_NICKNAME_LENGTH}
-          />
-          <button
-            type="submit"
-            className={`w-20 h-10 text-white bg-primary rounded-3xl ${
-              nickname.length === 0 ? 'opacity-50 cursor-not-allowed' : 'opacity-100'
-            }`}
-            disabled={nickname.length === 0}
-          >
-            참가하기
-          </button>
-        </div>
-      </form>
+      <NicknameForm onSubmit={handleSubmit} isLoading={isSubmitting} />
     </div>
   );
 }

--- a/packages/client/src/pages/nickname/ui/NicknameForm.tsx
+++ b/packages/client/src/pages/nickname/ui/NicknameForm.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import TrophyIcon from '@/shared/assets/icons/tropyhy.svg?react';
+import AvatarIcon from '@/shared/assets/icons/avatar.svg?react';
+
+const MAX_NICKNAME_LENGTH = 12;
+
+interface NicknameFormProps {
+  onSubmit: (nickname: string) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export const NicknameForm: React.FC<NicknameFormProps> = ({ onSubmit, isLoading = false }) => {
+  const [nickname, setNickname] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSubmit(nickname);
+  };
+
+  return (
+    <form className="flex flex-col items-center gap-3 w-fit" onSubmit={handleSubmit}>
+      <label
+        htmlFor="nickname"
+        className="flex gap-2 ml-1 items-center text-xl font-bold self-start"
+      >
+        <TrophyIcon />
+        닉네임
+      </label>
+      <div className="flex gap-3 items-center w-[650px] h-16 p-4 border-2 rounded-base border-border">
+        <div className="flex justify-center items-center w-8 h-8 rounded-full bg-weak">
+          <AvatarIcon />
+        </div>
+        <input
+          type="text"
+          id="nickname"
+          placeholder="Your Name"
+          className="w-[488px] bg-transparent focus:outline-none"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          maxLength={MAX_NICKNAME_LENGTH}
+        />
+        <button
+          type="submit"
+          className={`w-20 h-10 text-white bg-primary rounded-3xl 
+            ${!nickname || isLoading ? 'opacity-50 cursor-not-allowed' : 'opacity-100'}`}
+          disabled={!nickname || isLoading}
+        >
+          {isLoading ? '처리중...' : '참가하기'}
+        </button>
+      </div>
+    </form>
+  );
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
닉네임 페이지에서 비지니스 로직을 커스텀 훅으로 분리하고 `form` 태그를 컴포넌트로 분리했습니다.

### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
