### PR TITLE
[FE] - 메인 페이지 비즈니스 로직 및 컴포넌트 분리

### DIFF
--- a/packages/client/src/pages/main/hooks/useCheckPincodePossible.ts
+++ b/packages/client/src/pages/main/hooks/useCheckPincodePossible.ts
@@ -1,0 +1,18 @@
+import { toastController } from '@/features/toast/model/toastController';
+import { checkPincodePossible } from '@/shared/api/games';
+import { useCallback } from 'react';
+
+export const useCheckPincodePossible = () => {
+  const toast = toastController();
+  const navigateIfRoomAvailable = useCallback(async (pinCode: string, navigate: Function) => {
+    const response = await checkPincodePossible(pinCode);
+
+    if (!response.isPossible) {
+      toast.warning('방이 가득 찼습니다.');
+      return;
+    }
+    navigate(`/nickname/${pinCode}`);
+  }, []);
+
+  return { navigateIfRoomAvailable };
+};

--- a/packages/client/src/pages/main/hooks/useCheckPincodeStatus.ts
+++ b/packages/client/src/pages/main/hooks/useCheckPincodeStatus.ts
@@ -1,0 +1,46 @@
+import { toastController } from '@/features/toast/model/toastController';
+import { checkPincodeStatus } from '@/shared/api/games';
+import { deleteCookie } from '@/shared/utils/cookie';
+import { useCallback } from 'react';
+
+const mappingGameStatus = (status: string, pinCode: string) => {
+  switch (status) {
+    case 'WAITING':
+      return `/quiz/wait/${pinCode}`;
+    case 'IN PROGRESS':
+      return `/quiz/session/${pinCode}/1`;
+    case 'LEADERBOARD':
+    case 'END':
+      return `/quiz/session/${pinCode}/end`;
+    default:
+      return '/';
+  }
+};
+
+export const useCheckPincodeStatus = () => {
+  const toast = toastController();
+  const navigateBasedOnGameStatus = useCallback(
+    async (pinCode: string, sid: string, navigate: Function) => {
+      const response = await checkPincodeStatus(pinCode, sid);
+
+      if (!response.isPossible) {
+        toast.info(response.message || '게임이 종료되었습니다.');
+        deleteCookie('sid');
+        return;
+      }
+
+      const status = response.gameStatus;
+      if (!status) {
+        deleteCookie('sid');
+        navigate(`/nickname/${pinCode}`);
+        return;
+      }
+
+      const path = mappingGameStatus(status, pinCode);
+      navigate(path);
+    },
+    [],
+  );
+
+  return { navigateBasedOnGameStatus };
+};

--- a/packages/client/src/pages/main/index.tsx
+++ b/packages/client/src/pages/main/index.tsx
@@ -1,76 +1,42 @@
 import { toastController } from '@/features/toast/model/toastController';
-import { getPincodeExist, checkPincodePossible, checkPincodeStatus } from '@/shared/api/games';
+import { getPincodeExist } from '@/shared/api/games';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import FloatingSquare from './ui/FloatingSquare';
-import FloatingQuestion from './ui/FloatingQuestion';
-import { getCookie, deleteCookie } from '@/shared/utils/cookie';
-
-const mappingGameStatus = (status: string, pinCode: string) => {
-  switch (status) {
-    case 'WAITING':
-      return `/quiz/wait/${pinCode}`;
-    case 'IN PROGRESS':
-      return `/quiz/session/${pinCode}/1`;
-    case 'LEADERBOARD':
-      return `/quiz/session/${pinCode}/end`;
-    case 'END':
-      return `/quiz/session/${pinCode}/end`;
-    default:
-      return '/';
-  }
-};
+import { getCookie } from '@/shared/utils/cookie';
+import { useCheckPincodeStatus } from './hooks/useCheckPincodeStatus';
+import { useCheckPincodePossible } from './hooks/useCheckPincodePossible';
+import MainPageBackground from './ui/MainPageBackground';
 
 export default function MainPage() {
   const [pinCode, setPinCode] = useState<string>('');
   const navigate = useNavigate();
   const toast = toastController();
+  const { navigateBasedOnGameStatus } = useCheckPincodeStatus();
+  const { navigateIfRoomAvailable } = useCheckPincodePossible();
 
-  const handleClick = async () => {
+  const handleQuizJoin = async () => {
     if (!pinCode) {
       toast.warning('코드를 입력해주세요.');
       return;
     }
-    const response = await getPincodeExist(pinCode);
 
-    if (response.isExist) {
-      const sid = getCookie('sid');
-      if (sid) {
-        const response = await checkPincodeStatus(pinCode, sid);
-        if (response.isPossible) {
-          const status = response.gameStatus;
-          if (!status) {
-            deleteCookie('sid');
-            navigate(`/nickname/${pinCode}`);
-          } else {
-            const path = mappingGameStatus(status, pinCode);
-            navigate(path);
-          }
-        } else {
-          if (response.message) {
-            toast.info(response.message);
-          } else {
-            toast.info('게임이 종료되었습니다.');
-          }
-          deleteCookie('sid');
-        }
-      } else {
-        const checkResponse = await checkPincodePossible(pinCode);
-        console.log(checkResponse);
-        if (checkResponse.isPossible) {
-          navigate(`/nickname/${pinCode}`);
-        } else {
-          toast.warning('방이 가득 찼습니다.');
-        }
-      }
+    const response = await getPincodeExist(pinCode);
+    if (!response.isExist) {
+      toast.warning('잘못된 코드입니다.');
       return;
     }
-    toast.error('잘못된 코드입니다.');
+
+    const sid = getCookie('sid');
+    if (!sid) {
+      await navigateIfRoomAvailable(pinCode, navigate);
+      return;
+    }
+    await navigateBasedOnGameStatus(pinCode, sid, navigate);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      handleClick();
+      handleQuizJoin();
     }
   };
 
@@ -79,31 +45,7 @@ export default function MainPage() {
   };
   return (
     <div className="relative min-h-screen bg-gradient-to-br from-blue-50 via-sky-50 to-blue-100 flex flex-col items-center justify-center p-8 overflow-hidden">
-      <FloatingSquare
-        color="from-yellow-300/80 to-yellow-400/80"
-        size="128"
-        position="top-20 left-[20%]"
-        delay={0}
-      />
-      <FloatingSquare
-        color="from-green-300/80 to-green-400/80"
-        size="160"
-        position="top-40 right-[20%]"
-        delay={0.5}
-      />
-      <FloatingSquare
-        color="from-blue-400/80 to-blue-500/80"
-        size="192"
-        position="bottom-20 left-[20%]"
-        delay={1}
-      />
-      <FloatingSquare
-        color="from-pink-300/80 to-pink-400/80"
-        size="144"
-        position="bottom-40 right-[20%]"
-        delay={1.5}
-      />
-      <FloatingQuestion position="top-[170px] right-1/3" delay={0} />
+      <MainPageBackground />
       <div className="text-center mb-12 z-10">
         <h1 className="text-6xl font-bold bg-gradient-to-r from-blue-500 via-sky-500 to-blue-600 text-transparent bg-clip-text mb-4">
           You Quiz
@@ -122,7 +64,7 @@ export default function MainPage() {
           />
           <button
             className={`h-14 px-8 bg-gradient-to-r from-blue-500 to-sky-500 ${pinCode ? 'hover:from-blue-600 hover:to-sky-600' : ''}  rounded-xl text-white shadow-lg shadow-blue-500/30 cursor-pointer`}
-            onClick={handleClick}
+            onClick={handleQuizJoin}
           >
             퀴즈 참가하기
           </button>

--- a/packages/client/src/pages/main/ui/MainPageBackground.tsx
+++ b/packages/client/src/pages/main/ui/MainPageBackground.tsx
@@ -1,0 +1,34 @@
+import FloatingQuestion from './FloatingQuestion';
+import FloatingSquare from './FloatingSquare';
+
+export default function MainPageBackground() {
+  return (
+    <>
+      <FloatingSquare
+        color="from-yellow-300/80 to-yellow-400/80"
+        size="128"
+        position="top-20 left-[20%]"
+        delay={0}
+      />
+      <FloatingSquare
+        color="from-green-300/80 to-green-400/80"
+        size="160"
+        position="top-40 right-[20%]"
+        delay={0.5}
+      />
+      <FloatingSquare
+        color="from-blue-400/80 to-blue-500/80"
+        size="192"
+        position="bottom-20 left-[20%]"
+        delay={1}
+      />
+      <FloatingSquare
+        color="from-pink-300/80 to-pink-400/80"
+        size="144"
+        position="bottom-40 right-[20%]"
+        delay={1.5}
+      />
+      <FloatingQuestion position="top-[170px] right-1/3" delay={0} />
+    </>
+  );
+}


### PR DESCRIPTION
## #2 컴포넌트 최적화
<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용
메인 페이지 비즈니스 로직을 커스텀 훅으로 빼서 `handleQuizJoin` 함수에 사용하도록 변경
- `checkPincodeStatus` 커스텀 훅을 통해 핀 코드의 상태에 따라 재접속 기능 분리
- `checkPincodePossible` 커스텀 훅을 통해 방에 접속 상태에 따라 네비게이트 기능 분리

`FloatingQuestion` `FloatingSquare`를 배경으로 쓰는 코드가 불필요하게 길다고 판단하였습니다.
**배경** 이라는 키워드로 나눌 수 있을 것 같아 `MainPageBackground` 컴포넌트로 분리하였습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 💬리뷰 요구사항
커스텀 훅, 메인 페이지에서의 관심사 분리가 올바르게 되었는지 리뷰 부탁드립니다~
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
