### PR TITLE
[FE] - 퀴즈 생성 컴포넌트 리팩토링

### DIFF
--- a/packages/client/src/pages/quiz-create/contexts/quizContext.tsx
+++ b/packages/client/src/pages/quiz-create/contexts/quizContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useState } from 'react';
+import { QuizContextValue, QuizData } from './quizContext.types';
+
+export const INITIAL_QUIZ_VALUE: QuizData = {
+  content: '',
+  quizType: 'MC',
+  timeLimit: 30,
+  point: 1000,
+  position: 0,
+  choices: [
+    { content: '', isCorrect: false, position: 0 },
+    { content: '', isCorrect: false, position: 1 },
+  ],
+};
+
+export const QuizContext = createContext<QuizContextValue | undefined>(undefined);
+
+export const QuizProvider = ({ children }: { children: React.ReactNode }) => {
+  const [quizzes, setQuizzes] = useState<QuizData[]>([{ ...INITIAL_QUIZ_VALUE }]);
+  const [currentQuizIndex, setCurrentQuizIndex] = useState(0);
+
+  return (
+    <QuizContext.Provider value={{ quizzes, setQuizzes, currentQuizIndex, setCurrentQuizIndex }}>
+      {children}
+    </QuizContext.Provider>
+  );
+};

--- a/packages/client/src/pages/quiz-create/contexts/quizContext.types.ts
+++ b/packages/client/src/pages/quiz-create/contexts/quizContext.types.ts
@@ -1,0 +1,21 @@
+export interface QuizData {
+  content: string;
+  quizType: 'MC' | 'TF';
+  timeLimit: number;
+  point: number;
+  position: number;
+  choices: Choice[];
+}
+
+interface Choice {
+  content: string;
+  isCorrect: boolean;
+  position: number;
+}
+
+export interface QuizContextValue {
+  quizzes: QuizData[];
+  setQuizzes: React.Dispatch<React.SetStateAction<QuizData[]>>;
+  currentQuizIndex: number;
+  setCurrentQuizIndex: React.Dispatch<React.SetStateAction<number>>;
+}

--- a/packages/client/src/pages/quiz-create/contexts/useQuizContext.ts
+++ b/packages/client/src/pages/quiz-create/contexts/useQuizContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { QuizContext } from './quizContext';
+
+export const useQuizContext = () => {
+  const context = useContext(QuizContext);
+  if (!context) {
+    throw new Error('useQuizContext must be used within a QuizProvider');
+  }
+  return context;
+};

--- a/packages/client/src/pages/quiz-create/index.tsx
+++ b/packages/client/src/pages/quiz-create/index.tsx
@@ -1,126 +1,16 @@
-import { useState } from 'react';
-
-import { CustomButton } from '@/shared/ui/buttons';
-import PlusIcon from '@/shared/assets/icons/plus.svg?react';
 import QuizCreateSection from './ui/QuizCreateSection';
-import { useParams } from 'react-router-dom';
-import { useCreateQuiz } from '@/shared/hooks/quizzes';
-
-interface Choice {
-  content: string;
-  isCorrect: boolean;
-  position: number;
-}
-
-export interface QuizData {
-  content: string;
-  quizType: 'MC' | 'TF';
-  timeLimit: number;
-  point: number;
-  position: number;
-  choices: Choice[];
-}
-
-const INITIAL_QUIZ_VALUE: QuizData = {
-  content: '',
-  quizType: 'MC',
-  timeLimit: 30,
-  point: 1000,
-  position: 0,
-  choices: [
-    { content: '', isCorrect: false, position: 0 },
-    { content: '', isCorrect: false, position: 1 },
-  ],
-};
+import { QuizProvider } from './contexts/quizContext';
+import QuizNavigation from './ui/QuizNavigatioin';
+import QuizActions from './ui/QuizActions';
 
 export default function QuizCreatePage() {
-  const { classId } = useParams();
-  const [currentQuizIndex, setCurrentQuizIndex] = useState(0);
-  const [quizzes, setQuizzes] = useState<QuizData[]>([INITIAL_QUIZ_VALUE]);
-  const [forceRender, setForceRender] = useState(1);
-  const mutation = useCreateQuiz();
-
-  const addNewQuiz = () => {
-    setQuizzes((prev) => [...prev, INITIAL_QUIZ_VALUE]);
-    setCurrentQuizIndex((prev) => prev + 1);
-  };
-
-  const removeQuiz = (index: number) => {
-    if (quizzes.length === 1) return;
-    setQuizzes((prev) => {
-      const newQuizzes = [...prev];
-      newQuizzes.splice(index, 1);
-
-      if (index === prev.length - 1) {
-        setCurrentQuizIndex((prevIndex) => Math.max(0, prevIndex - 1));
-      }
-      return newQuizzes;
-    });
-    setForceRender((prev) => prev + 1);
-  };
-
-  const handlePreQuiz = () => {
-    if (currentQuizIndex === 0) return;
-    setCurrentQuizIndex((prev) => prev - 1);
-  };
-
-  const handleNextQuiz = () => {
-    if (currentQuizIndex === quizzes.length - 1) return;
-    setCurrentQuizIndex((prev) => prev + 1);
-  };
-
-  const handleCreateQuiz = () => {
-    const quizzesData = {
-      quizzes: quizzes,
-    };
-    mutation.mutate({ quizData: quizzesData, classId: Number(classId) });
-  };
-
   return (
-    <div className="flex flex-col w-full mt-6 mx-6">
-      <div className=" flex gap-4 bg-white rounded-base p-4 mb-4">
-        <button className="text-weak-md" onClick={handlePreQuiz}>
-          이전 문제
-        </button>
-        <button className="text-weak-md" onClick={handleNextQuiz}>
-          다음 문제
-        </button>
-        <div className="flex-1 flex justify-end text-weak-md">문제 유형: 객관식</div>
+    <QuizProvider>
+      <div className="flex flex-col w-full mt-6 mx-6">
+        <QuizNavigation />
+        <QuizCreateSection />
+        <QuizActions />
       </div>
-      <QuizCreateSection
-        key={currentQuizIndex + forceRender}
-        currentQuizIndex={currentQuizIndex}
-        quizData={quizzes[currentQuizIndex]}
-        onQuizUpdate={(updatedData: QuizData) => {
-          setQuizzes((prev) => {
-            const newQuizzes = [...prev];
-            newQuizzes[currentQuizIndex] = { ...updatedData, position: currentQuizIndex };
-            return newQuizzes;
-          });
-        }}
-      />
-      <div className="flex justify-between mt-10 mr-6">
-        <div className="flex gap-6">
-          <CustomButton
-            Icon={PlusIcon}
-            type="outline"
-            size="md"
-            color="primary"
-            label="문제 추가하기"
-            onClick={addNewQuiz}
-          />
-          <button
-            className="flex items-center min-w-fit h-[44px] px-4 py-2.5 bg-white border-2 border-red-500 text-red-500 rounded-base font-medium leading-none text-md
-            disabled:bg-gray-200 disabled:border-gray-300 disabled:text-gray-400 disabled:cursor-not-allowed"
-            onClick={() => removeQuiz(currentQuizIndex)}
-            disabled={quizzes.length === 1}
-          >
-            <PlusIcon className="w-5 h-5 mr-1 transform rotate-45" />
-            문제 삭제하기
-          </button>
-        </div>
-        <CustomButton label="퀴즈 발행하기" onClick={handleCreateQuiz} />
-      </div>
-    </div>
+    </QuizProvider>
   );
 }

--- a/packages/client/src/pages/quiz-create/ui/QuizActions.tsx
+++ b/packages/client/src/pages/quiz-create/ui/QuizActions.tsx
@@ -1,0 +1,62 @@
+import { CustomButton } from '@/shared/ui/buttons';
+import PlusIcon from '@/shared/assets/icons/plus.svg?react';
+import { useQuizContext } from '../contexts/useQuizContext';
+import { useCreateQuiz } from '@/shared/hooks/quizzes';
+import { INITIAL_QUIZ_VALUE } from '../contexts/quizContext';
+import { useParams } from 'react-router-dom';
+
+export default function QuizActions() {
+  const { quizzes, currentQuizIndex, setQuizzes, setCurrentQuizIndex } = useQuizContext();
+  const createQuizMutation = useCreateQuiz();
+  const { classId } = useParams();
+
+  const addNewQuiz = () => {
+    setQuizzes((prev) => [...prev, { ...INITIAL_QUIZ_VALUE }]);
+    setCurrentQuizIndex((prev) => prev + 1);
+  };
+
+  const removeQuiz = (index: number) => {
+    if (quizzes.length === 1) return;
+    setQuizzes((prev) => {
+      const newQuizzes = [...prev];
+      newQuizzes.splice(index, 1);
+
+      if (index === prev.length - 1) {
+        setCurrentQuizIndex((prevIndex) => Math.max(0, prevIndex - 1));
+      }
+      return newQuizzes;
+    });
+  };
+
+  const handleCreateQuiz = () => {
+    const quizzesData = {
+      quizzes: quizzes,
+    };
+    createQuizMutation.mutate({ quizData: quizzesData, classId: Number(classId) });
+  };
+
+  return (
+    <div className="flex justify-between mt-10 mr-6">
+      <div className="flex gap-6">
+        <CustomButton
+          Icon={PlusIcon}
+          type="outline"
+          size="md"
+          color="primary"
+          label="문제 추가하기"
+          onClick={addNewQuiz}
+        />
+        <button
+          className="flex items-center min-w-fit h-[44px] px-4 py-2.5 bg-white border-2 border-red-500 text-red-500 rounded-base font-medium leading-none text-md
+            disabled:bg-gray-200 disabled:border-gray-300 disabled:text-gray-400 disabled:cursor-not-allowed"
+          onClick={() => removeQuiz(currentQuizIndex)}
+          disabled={quizzes.length === 1}
+        >
+          <PlusIcon className="w-5 h-5 mr-1 transform rotate-45" />
+          문제 삭제하기
+        </button>
+      </div>
+      <CustomButton label="퀴즈 발행하기" onClick={handleCreateQuiz} />
+    </div>
+  );
+}

--- a/packages/client/src/pages/quiz-create/ui/QuizCreateSection.tsx
+++ b/packages/client/src/pages/quiz-create/ui/QuizCreateSection.tsx
@@ -5,22 +5,23 @@ import InputBox from '@/shared/ui/input-box/InputBox';
 import AnswerBox from './AnswerBox';
 import TimeSelectBox from './TimeSelectBox';
 import PlusIcon from '@/shared/assets/icons/plus.svg?react';
+import { useQuizContext } from '../contexts/useQuizContext';
+import { QuizData } from '../contexts/quizContext.types';
 
-import { QuizData } from '../index';
+export default function QuizCreateSection() {
+  const { quizzes, currentQuizIndex, setQuizzes } = useQuizContext();
+  const quizData = quizzes[currentQuizIndex];
 
-interface QuizCreateSectionProps {
-  quizData: QuizData;
-  currentQuizIndex: number;
-  onQuizUpdate: (updatedData: QuizData) => void;
-}
-
-export default function QuizCreateSection({
-  quizData,
-  currentQuizIndex,
-  onQuizUpdate,
-}: QuizCreateSectionProps) {
   const [showTimeSelect, setShowTimeSelect] = useState(false);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const onQuizUpdate = (updatedData: QuizData) => {
+    setQuizzes((prev) => {
+      const newQuizzes = [...prev];
+      newQuizzes[currentQuizIndex] = { ...updatedData, position: currentQuizIndex };
+      return newQuizzes;
+    });
+  };
 
   const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -41,7 +42,7 @@ export default function QuizCreateSection({
   return (
     <section>
       <article className="min-w-content min-h-[532px] flex flex-col gap-1 items-center bg-white rounded-base p-6">
-        <p className="self-start relative">
+        <div className="self-start relative">
           <span className="text-weak-md mr-3">{`${currentQuizIndex + 1}번 퀴즈`}</span>
           <span
             className="text-weak-sm cursor-pointer"
@@ -56,15 +57,15 @@ export default function QuizCreateSection({
             />
           )}
           <span className="text-sm text-gray-500 ml-5">* 복수 선택 가능</span>
-        </p>
-        <p className="w-full">
+        </div>
+        <div className="w-full">
           <InputBox
             placeholder="문제를 입력해주세요"
             type="box"
             onSubmit={(value) => onQuizUpdate({ ...quizData, content: value })}
             initialValue={quizData.content}
           />
-        </p>
+        </div>
         <div className="flex flex-col gap-4 w-full mt-6">
           {quizData.choices.map((choice, index) => (
             <AnswerBox

--- a/packages/client/src/pages/quiz-create/ui/QuizNavigatioin.tsx
+++ b/packages/client/src/pages/quiz-create/ui/QuizNavigatioin.tsx
@@ -1,0 +1,27 @@
+import { useQuizContext } from '../contexts/useQuizContext';
+
+export default function QuizNavigation() {
+  const { currentQuizIndex, setCurrentQuizIndex, quizzes } = useQuizContext();
+
+  const handlePreQuiz = () => {
+    if (currentQuizIndex === 0) return;
+    setCurrentQuizIndex((prev) => prev - 1);
+  };
+
+  const handleNextQuiz = () => {
+    if (currentQuizIndex === quizzes.length - 1) return;
+    setCurrentQuizIndex((prev) => prev + 1);
+  };
+
+  return (
+    <div className=" flex gap-4 bg-white rounded-base p-4 mb-4">
+      <button className="text-weak-md" onClick={handlePreQuiz}>
+        이전 문제
+      </button>
+      <button className="text-weak-md" onClick={handleNextQuiz}>
+        다음 문제
+      </button>
+      <div className="flex-1 flex justify-end text-weak-md">문제 유형: 객관식</div>
+    </div>
+  );
+}

--- a/packages/client/src/shared/ui/input-box/InputBox.tsx
+++ b/packages/client/src/shared/ui/input-box/InputBox.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef } from 'react';
+import { useState, forwardRef, useEffect } from 'react';
 import SubmitIcon from '@/shared/assets/icons/arrow-up-circle.svg?react';
 
 interface InputBoxProps {
@@ -34,6 +34,10 @@ export default forwardRef(function InputBox(
     }
     onKeyDown?.(e);
   };
+
+  useEffect(() => {
+    setValue(initialValue ?? '');
+  }, [initialValue]);
 
   return (
     <div className="relative">


### PR DESCRIPTION
## #2 [컴포넌트 최적화]: 페이지 별 컴포넌트 최적화

## 📝작업 내용
- 퀴즈 생성 페이지 컴포넌트 분리
- Context를 사용하여 `quizzes` `currentIndex` 를 퀴즈생성페이지 내에서 상태를 공유할 수 있도록 만듦
- `useQuizContext` 커스텀 훅을 통해 쉽게 상태를 공유할 수 있도록 만듦
- `InputBox`의 초기값이 변할 때 변하지 않는 에러 해결
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

## 💬리뷰 요구사항
context를 사용하여 우선 컴포넌트를 가독성 및 유지보수가 편한 상태로 만들었습니다. 하지만, 리렌더링을 최소화하려고 하였지만, 여전히 해결되지 않은 상태입니다. quizzes 라는 큰 객체를 중앙 집중식으로 다루고 있기 때문에 발생하는 문제라고 파악했는데, 리렌더링을 줄이기 위한 좋은 데이터 구조가 생각난다면 리뷰 해주세요~
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

