### PR TITLE
[FE] - 퀴즈 마스터 세션 컴포넌트 리팩토링, ContextAPI 도입

### DIFF
--- a/packages/client/src/pages/quiz-master-session/context/quizContext.tsx
+++ b/packages/client/src/pages/quiz-master-session/context/quizContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { RefetchOptions, QueryObserverResult } from '@tanstack/react-query';
+
+import { useQuizSession } from '@/pages/quiz-session/model/hooks/useQuizSession';
+import { getQuizSocket } from '@/shared/utils/socket';
+
+interface ShowQuizResponse {
+  quizMaxNum: number;
+  currentQuizData: QuizData;
+  isLast: boolean;
+  startTime: number;
+  participantLength: number;
+}
+
+interface QuizProviderValue {
+  quiz: ShowQuizResponse;
+  refetch: (options?: RefetchOptions) => Promise<QueryObserverResult<ShowQuizResponse, Error>>;
+  initializeStates: boolean;
+  setInitializeStates: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const QuizContext = createContext<QuizProviderValue | undefined>(undefined);
+
+export const QuizProvider = ({ children }: { children: React.ReactNode }) => {
+  const socket = getQuizSocket();
+  const { pinCode, id } = useParams();
+  const { data: quiz, refetch } = useQuizSession({
+    socket,
+    pinCode: pinCode as string,
+    quizOrder: parseInt(id as string),
+  });
+  const [initializeStates, setInitializeStates] = useState(false);
+
+  return (
+    <QuizContext.Provider value={{ quiz, refetch, initializeStates, setInitializeStates }}>
+      {children}
+    </QuizContext.Provider>
+  );
+};

--- a/packages/client/src/pages/quiz-master-session/hooks/useQuizContext.ts
+++ b/packages/client/src/pages/quiz-master-session/hooks/useQuizContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { QuizContext } from '../context/quizContext';
+
+export const useQuizContext = () => {
+  const context = useContext(QuizContext);
+  if (!context) {
+    throw new Error('useQuizContext is undefined. Please check useQuizSession');
+  }
+  return context;
+};

--- a/packages/client/src/pages/quiz-master-session/hooks/useStatisticsState.ts
+++ b/packages/client/src/pages/quiz-master-session/hooks/useStatisticsState.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+import { usePersistState } from '@/shared/hooks/usePersistState';
+
+import { INITIAL_MASTER_STATISTICS, INITIAL_EMOJI } from '@/shared/constants/initialState';
+import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response';
+
+interface HistoryItem {
+  user: string;
+  submitTime: number;
+  elapsedTime: number;
+  displayTime: string;
+}
+
+interface useStatisticsStateProps {
+  initializeStates: boolean;
+  setInitializeStates: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const useStatisticsState = ({
+  initializeStates,
+  setInitializeStates,
+}: useStatisticsStateProps) => {
+  const [masterStatistics, setMasterStatistics] = usePersistState<MasterStatisticsResponse>(
+    'masterStatistics',
+    INITIAL_MASTER_STATISTICS,
+  );
+  const [reactionStats, setReactionStats] = usePersistState('reactionStats', INITIAL_EMOJI);
+  const [history, setHistory] = usePersistState<HistoryItem[]>('history', []);
+
+  const initializeStatistics = () => {
+    setMasterStatistics(INITIAL_MASTER_STATISTICS);
+    setReactionStats(INITIAL_EMOJI);
+    setHistory([]);
+  };
+
+  useEffect(() => {
+    initializeStatistics();
+    setInitializeStates(false);
+  }, [initializeStates]);
+
+  return {
+    masterStatistics,
+    setMasterStatistics,
+    reactionStats,
+    setReactionStats,
+    history,
+    setHistory,
+  };
+};

--- a/packages/client/src/pages/quiz-master-session/index.lazy.tsx
+++ b/packages/client/src/pages/quiz-master-session/index.lazy.tsx
@@ -1,59 +1,17 @@
-import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import { getCookie } from '@/shared/utils/cookie';
 import { getQuizSocket } from '@/shared/utils/socket';
-
-import { useQuizSession } from '../quiz-session/model/hooks/useQuizSession';
 import QuizMasterHeader from './ui/QuizMasterHeader';
 import Statistics from './ui/Statistics';
-import { clearLocalStorage } from '@/shared/utils/clearLocalStorage';
-import { MASTER_LOCAL_STORAGE_KEYS } from '@/shared/constants/masterLocalStorageKey';
 
 export default function QuizMasterSessionLazyPage() {
   const { pinCode, id } = useParams();
-  const navigate = useNavigate();
   const socket = getQuizSocket();
-  const [initializeStates, setInitializeStates] = useState(false);
-
-  const { data: quiz, refetch } = useQuizSession({
-    socket,
-    pinCode: pinCode as string,
-    quizOrder: parseInt(id as string),
-  });
-
-  const handleNextQuiz = () => {
-    if (quiz.isLast) {
-      socket.emit('end quiz', { pinCode, sid: getCookie('sid') });
-      clearLocalStorage(MASTER_LOCAL_STORAGE_KEYS);
-      navigate(`/quiz/session/${pinCode}/end`);
-      return;
-    }
-
-    socket.emitWithAck('start quiz', { pinCode, sid: getCookie('sid') }).then(() => {
-      clearLocalStorage(MASTER_LOCAL_STORAGE_KEYS);
-      navigate(`/quiz/session/host/${pinCode}/${parseInt(id as string) + 1}`);
-      refetch();
-      setInitializeStates(true);
-    });
-  };
 
   return (
     <div className="w-screen min-h-screen">
-      <QuizMasterHeader
-        quizData={quiz.currentQuizData}
-        startTime={quiz.startTime}
-        timeLimit={quiz.currentQuizData.timeLimit}
-        handleNextQuiz={handleNextQuiz}
-        pinCode={pinCode as string}
-        socket={socket}
-      />
-      <Statistics
-        quizData={quiz.currentQuizData}
-        initializeStates={initializeStates}
-        setInitializeStates={setInitializeStates}
-        totalParticipants={quiz.participantLength}
-      />
+      <QuizMasterHeader pinCode={pinCode as string} socket={socket} id={id as string} />
+      <Statistics />
     </div>
   );
 }

--- a/packages/client/src/pages/quiz-master-session/index.tsx
+++ b/packages/client/src/pages/quiz-master-session/index.tsx
@@ -1,10 +1,13 @@
 import AsyncBoundary from '@/shared/boundary/AsyncBoundary';
 import QuizMasterSessionLazyPage from './index.lazy';
+import { QuizProvider } from './context/quizContext';
 
 export default function QuizMasterSession() {
   return (
     <AsyncBoundary>
-      <QuizMasterSessionLazyPage />
+      <QuizProvider>
+        <QuizMasterSessionLazyPage />
+      </QuizProvider>
     </AsyncBoundary>
   );
 }

--- a/packages/client/src/pages/quiz-master-session/ui/AnswerChart.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/AnswerChart.tsx
@@ -10,13 +10,11 @@ import {
   Cell,
 } from 'recharts';
 
+import { useQuizContext } from '../hooks/useQuizContext';
 import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response';
-import { QuizData } from '@youquiz/shared/interfaces/utils/quizdata.interface';
 
 interface AnswerStatProps {
   answerStats: MasterStatisticsResponse['choiceStatus'];
-  quizData: QuizData;
-  totalParticipants: number;
 }
 
 const calculateTickCount = (maxValue: number): number => {
@@ -28,15 +26,17 @@ const calculateTickCount = (maxValue: number): number => {
   return Math.max(divisors[Math.min(divisors.length - 1, maxTicks - 1)], 2);
 };
 
-export default function AnswerGraph({ answerStats, quizData, totalParticipants }: AnswerStatProps) {
-  const answerStatsArray = quizData.choices
+export default function AnswerGraph({ answerStats }: AnswerStatProps) {
+  const { quiz } = useQuizContext();
+
+  const answerStatsArray = quiz.currentQuizData.choices
     .sort((a, b) => a.position - b.position)
     .map((choice, index) => ({
       answer: `${index + 1}번: ${choice.content} ${choice.isCorrect ? '(정답)' : ''}`,
       count: answerStats[index] || 0,
       isCorrect: choice.isCorrect,
     }));
-  const tickCount = calculateTickCount(totalParticipants);
+  const tickCount = calculateTickCount(quiz.participantLength);
 
   return (
     <ResponsiveContainer width="100%" height="100%">
@@ -66,7 +66,7 @@ export default function AnswerGraph({ answerStats, quizData, totalParticipants }
           axisLine={false}
           tickLine={false}
           tickCount={tickCount}
-          domain={[0, totalParticipants]}
+          domain={[0, quiz.participantLength]}
         />
         <Tooltip formatter={(value: number) => [`${value}명`, '참여자 수']} />
         <Legend formatter={() => '참여자 수'} />

--- a/packages/client/src/pages/quiz-master-session/ui/QuizMasterHeader.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/QuizMasterHeader.tsx
@@ -33,7 +33,7 @@ export default function QuizMasterHeader({ pinCode, socket, id }: QuizMasterHead
 
     socket.emitWithAck('start quiz', { pinCode, sid: getCookie('sid') }).then(() => {
       clearLocalStorage(MASTER_LOCAL_STORAGE_KEYS);
-      navigate(`/quiz/session/host/${pinCode}/${parseInt(id as string) + 1}`);
+      navigate(`/quiz/session/host/${pinCode}/${parseInt(id) + 1}`);
       refetch();
       setInitializeStates(true);
     });

--- a/packages/client/src/pages/quiz-master-session/ui/QuizMasterHeader.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/QuizMasterHeader.tsx
@@ -1,37 +1,55 @@
-import { usePersistState } from '@/shared/hooks/usePersistState';
-import { useEffect } from 'react';
-
 import { Socket } from 'socket.io-client';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { usePersistState } from '@/shared/hooks/usePersistState';
+import { useQuizContext } from '../hooks/useQuizContext';
+import { getCookie } from '@/shared/utils/cookie';
+import { clearLocalStorage } from '@/shared/utils/clearLocalStorage';
+import { MASTER_LOCAL_STORAGE_KEYS } from '@/shared/constants/masterLocalStorageKey';
 
 interface QuizMasterHeaderProps {
-  quizData: QuizData;
-  startTime: number;
-  timeLimit: number;
-  handleNextQuiz: () => void;
   pinCode: string;
+  id: string;
   socket: Socket;
 }
 
-export default function QuizMasterHeader({
-  quizData,
-  startTime,
-  timeLimit,
-  handleNextQuiz,
-  pinCode,
-  socket,
-}: QuizMasterHeaderProps) {
-  const [remainingTime, setRemainingTime] = usePersistState('remainingTime', timeLimit);
+export default function QuizMasterHeader({ pinCode, socket, id }: QuizMasterHeaderProps) {
+  const navigate = useNavigate();
+  const { quiz, refetch, setInitializeStates } = useQuizContext();
+
+  const [remainingTime, setRemainingTime] = usePersistState(
+    'remainingTime',
+    quiz.currentQuizData.timeLimit,
+  );
+
+  const handleNextQuiz = () => {
+    if (quiz.isLast) {
+      socket.emit('end quiz', { pinCode, sid: getCookie('sid') });
+      clearLocalStorage(MASTER_LOCAL_STORAGE_KEYS);
+      navigate(`/quiz/session/${pinCode}/end`);
+      return;
+    }
+
+    socket.emitWithAck('start quiz', { pinCode, sid: getCookie('sid') }).then(() => {
+      clearLocalStorage(MASTER_LOCAL_STORAGE_KEYS);
+      navigate(`/quiz/session/host/${pinCode}/${parseInt(id as string) + 1}`);
+      refetch();
+      setInitializeStates(true);
+    });
+  };
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      const timeLeft = timeLimit - Math.floor((Date.now() - startTime) / 1000);
+      const timeLeft =
+        quiz.currentQuizData.timeLimit - Math.floor((Date.now() - quiz.startTime) / 1000);
       setRemainingTime(timeLeft);
     }, 1000);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, [startTime]);
+  }, [quiz.startTime]);
 
   useEffect(() => {
     if (remainingTime === 0) {
@@ -45,7 +63,7 @@ export default function QuizMasterHeader({
         <div>
           <h1 className="text-xl font-bold mb-2">실시간 통계</h1>
           <p className="text-2xl font-bold mb-2">
-            Q{quizData.position + 1}. {quizData.content}
+            Q{quiz.currentQuizData.position + 1}. {quiz.currentQuizData.content}
           </p>
         </div>
         <div>

--- a/packages/client/src/pages/quiz-master-session/ui/RightPanel.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/RightPanel.tsx
@@ -1,0 +1,36 @@
+import RecentSubmittedAnswers from './RecentSubmittedAnswers';
+import EmojiChart from './EmojiChart';
+
+import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response';
+
+interface HistoryItem {
+  user: string;
+  submitTime: number;
+  elapsedTime: number;
+  displayTime: string;
+}
+
+interface RightPanelProps {
+  masterStatistics: MasterStatisticsResponse;
+  history: HistoryItem[];
+  setHistory: React.Dispatch<React.SetStateAction<HistoryItem[]>>;
+  reactionStats: { easy: number; hard: number };
+}
+
+export default function RightPanel({
+  masterStatistics,
+  history,
+  setHistory,
+  reactionStats,
+}: RightPanelProps) {
+  return (
+    <div className="flex flex-col gap-2 max-h-[calc(100vh-300px)]">
+      <RecentSubmittedAnswers
+        userSubmitHistory={masterStatistics.submitHistory}
+        history={history}
+        setHistory={setHistory}
+      />
+      <EmojiChart reactionStats={reactionStats} />
+    </div>
+  );
+}

--- a/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
@@ -1,5 +1,3 @@
-import { INITIAL_MASTER_STATISTICS } from '@/shared/constants/initialState';
-import { INITIAL_EMOJI } from '@/shared/constants/initialState';
 import AnswerGraph from './AnswerChart';
 import RecentSubmittedAnswers from './RecentSubmittedAnswers';
 import StatisticsGroup from './StatisticsGroup';
@@ -7,20 +5,14 @@ import EmojiChart from './EmojiChart';
 import { useEffect } from 'react';
 import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response/master-statistics.response.interface';
 import { getQuizSocket } from '@/shared/utils/socket';
-import { usePersistState } from '@/shared/hooks/usePersistState';
+
+import { useStatisticsState } from '../hooks/useStatisticsState';
 
 interface StatisticsProps {
   quizData: QuizData;
   initializeStates: boolean;
   setInitializeStates: React.Dispatch<React.SetStateAction<boolean>>;
   totalParticipants: number;
-}
-
-interface HistoryItem {
-  user: string;
-  submitTime: number;
-  elapsedTime: number;
-  displayTime: string;
 }
 
 export default function Statistics({
@@ -30,18 +22,14 @@ export default function Statistics({
   totalParticipants,
 }: StatisticsProps) {
   const socket = getQuizSocket();
-  const [masterStatistics, setMasterStatistics] = usePersistState<MasterStatisticsResponse>(
-    'masterStatistics',
-    INITIAL_MASTER_STATISTICS,
-  );
-  const [reactionStats, setReactionStats] = usePersistState('reactionStats', INITIAL_EMOJI);
-  const [history, setHistory] = usePersistState<HistoryItem[]>('history', []);
-
-  const initializeStatistics = () => {
-    setMasterStatistics(INITIAL_MASTER_STATISTICS);
-    setReactionStats(INITIAL_EMOJI);
-    setHistory([]);
-  };
+  const {
+    masterStatistics,
+    setMasterStatistics,
+    reactionStats,
+    setReactionStats,
+    history,
+    setHistory,
+  } = useStatisticsState({ initializeStates, setInitializeStates });
 
   useEffect(() => {
     const handleMasterStatistics = (response: MasterStatisticsResponse) => {
@@ -60,13 +48,6 @@ export default function Statistics({
       socket.off('emoji', handleReactionUpdate);
     };
   }, []);
-
-  useEffect(() => {
-    if (initializeStates) {
-      initializeStatistics();
-      setInitializeStates(false);
-    }
-  }, [initializeStates]);
 
   return (
     <>

--- a/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
@@ -1,12 +1,13 @@
-import AnswerGraph from './AnswerChart';
-import RecentSubmittedAnswers from './RecentSubmittedAnswers';
-import StatisticsGroup from './StatisticsGroup';
-import EmojiChart from './EmojiChart';
 import { useEffect } from 'react';
-import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response/master-statistics.response.interface';
-import { getQuizSocket } from '@/shared/utils/socket';
+
+import AnswerGraph from './AnswerChart';
+import StatisticsGroup from './StatisticsGroup';
+import StatisticsLayout from './StatisticsLayout';
+import RightPanel from './RightPanel';
 
 import { useStatisticsState } from '../hooks/useStatisticsState';
+import { getQuizSocket } from '@/shared/utils/socket';
+import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response/master-statistics.response.interface';
 
 interface StatisticsProps {
   quizData: QuizData;
@@ -52,21 +53,19 @@ export default function Statistics({
   return (
     <>
       <StatisticsGroup participantStatistics={masterStatistics} />
-      <div className="grid grid-cols-[3fr_1fr] gap-4 mx-5 h-[calc(100vh-300px)]">
+      <StatisticsLayout>
         <AnswerGraph
           answerStats={masterStatistics.choiceStatus}
           totalParticipants={totalParticipants}
           quizData={quizData}
         />
-        <div className="flex flex-col gap-2 max-h-[calc(100vh-300px)]">
-          <RecentSubmittedAnswers
-            userSubmitHistory={masterStatistics.submitHistory}
-            history={history}
-            setHistory={setHistory}
-          />
-          <EmojiChart reactionStats={reactionStats} />
-        </div>
-      </div>
+        <RightPanel
+          masterStatistics={masterStatistics}
+          history={history}
+          setHistory={setHistory}
+          reactionStats={reactionStats}
+        />
+      </StatisticsLayout>
     </>
   );
 }

--- a/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/Statistics.tsx
@@ -8,21 +8,11 @@ import RightPanel from './RightPanel';
 import { useStatisticsState } from '../hooks/useStatisticsState';
 import { getQuizSocket } from '@/shared/utils/socket';
 import { MasterStatisticsResponse } from '@youquiz/shared/interfaces/response/master-statistics.response.interface';
+import { useQuizContext } from '../hooks/useQuizContext';
 
-interface StatisticsProps {
-  quizData: QuizData;
-  initializeStates: boolean;
-  setInitializeStates: React.Dispatch<React.SetStateAction<boolean>>;
-  totalParticipants: number;
-}
-
-export default function Statistics({
-  quizData,
-  initializeStates,
-  setInitializeStates,
-  totalParticipants,
-}: StatisticsProps) {
+export default function Statistics() {
   const socket = getQuizSocket();
+  const { initializeStates, setInitializeStates } = useQuizContext();
   const {
     masterStatistics,
     setMasterStatistics,
@@ -54,11 +44,7 @@ export default function Statistics({
     <>
       <StatisticsGroup participantStatistics={masterStatistics} />
       <StatisticsLayout>
-        <AnswerGraph
-          answerStats={masterStatistics.choiceStatus}
-          totalParticipants={totalParticipants}
-          quizData={quizData}
-        />
+        <AnswerGraph answerStats={masterStatistics.choiceStatus} />
         <RightPanel
           masterStatistics={masterStatistics}
           history={history}

--- a/packages/client/src/pages/quiz-master-session/ui/StatisticsLayout.tsx
+++ b/packages/client/src/pages/quiz-master-session/ui/StatisticsLayout.tsx
@@ -1,0 +1,9 @@
+interface StatisticsLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function StatisticsLayout({ children }: StatisticsLayoutProps) {
+  return (
+    <div className="grid grid-cols-[3fr_1fr] gap-4 mx-5 h-[calc(100vh-300px)]">{children}</div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#2 
<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- ContextAPI 도입
  - `quiz` 데이터, `initializeStates` , `setInitializeStates`, `refetch` 를 Context로 전역적으로 활용할 수 있게 구현했습니다.
 
  - 결과 : Props로 넘겨받던 데이터들을 `context`를 통해서 주고 받아 props drilling 해소 및 더 깔끔한 컴포넌트 코드 완성
  
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/be6e0423-dff7-4acc-8768-47b8edf9197f" />

- 컴포넌트 수정
  - 직관적으로 레이아웃을 알아볼 수 있도록 컴포넌트 분리 및 수정 (`<RightPanel />` , `<StatisticsLayout>` 컴포넌트 추가 )

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/abbf7aaf-1c44-43f7-85cf-7e88245720e1" />

  - R


### 스크린샷

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
