### PR TITLE
[BE] 빈 문자열의 선택지도 허용하게 DTO 수정

### DIFF
--- a/packages/server/src/module/quiz/application/quiz.service.ts
+++ b/packages/server/src/module/quiz/application/quiz.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
 import { DataSource, InsertResult } from 'typeorm';
-import OpenAI from 'openai';
 import { QuizRepository } from '../infrastructure/quiz.repository';
 import { ChoiceRepository } from '../infrastructure/choice.repository';
 import { ClassRepository } from '../infrastructure/class.repository';
@@ -14,13 +13,11 @@ import { GetClassResponseDto } from '../presentation/dto/response/get-class.resp
 import { Class } from '../domain/entities/class.entity';
 import { OpenAiService } from 'src/config/ai/openai.config';
 import { CreateQuizWithAiDto } from '../presentation/dto/request/create-quiz-with-ai.request.dto';
-import { create } from 'domain';
 import { CreateQuizWithAiResponseDto } from '../presentation/dto/response/create-quiz-with-ai.response.dto';
 import { CreateChoiceWithAiDto } from '../presentation/dto/request/create-choice-with-ai.request.dto';
 import { CreateChoiceWithAiResponseDto } from '../presentation/dto/response/create-chioce-with-ai.response.dto';
 import { RedisService } from 'src/config/database/redis/redis.service';
 import { cosineSimilarity } from '../utils/cosine-similarity';
-
 
 @Injectable()
 export class QuizService {

--- a/packages/server/src/module/quiz/presentation/dto/request/create-choice-with-ai.request.dto.ts
+++ b/packages/server/src/module/quiz/presentation/dto/request/create-choice-with-ai.request.dto.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsNotEmpty, IsString, IsNumber, IsArray, ValidateNested, IsEnum } from 'class-validator';
 import { QUIZ_DIFFICULTY } from '@shared/constants/quiz-difficulty.enum';
-import { CreateChoiceRequestDto } from './create-choice.request.dto';
+import { UpdateUserChoiceWithAiRequestDto } from './update-user-choice-with-ai.request.dto';
 
 export class CreateChoiceWithAiDto {
   @IsString()
@@ -10,8 +10,8 @@ export class CreateChoiceWithAiDto {
 
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => CreateChoiceRequestDto)
-  choices: CreateChoiceRequestDto[];
+  @Type(() => UpdateUserChoiceWithAiRequestDto)
+  choices: UpdateUserChoiceWithAiRequestDto[];
 
   @IsEnum(QUIZ_DIFFICULTY)
   @IsNotEmpty()

--- a/packages/server/src/module/quiz/presentation/dto/request/create-choice.request.dto.ts
+++ b/packages/server/src/module/quiz/presentation/dto/request/create-choice.request.dto.ts
@@ -4,7 +4,7 @@ export class CreateChoiceRequestDto {
   @IsNumber()
   @IsNotEmpty()
   position: number;
-  
+
   @IsString()
   @IsNotEmpty()
   content: string;

--- a/packages/server/src/module/quiz/presentation/dto/request/update-user-choice-with-ai.request.dto.ts
+++ b/packages/server/src/module/quiz/presentation/dto/request/update-user-choice-with-ai.request.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsString, IsBoolean, IsNumber } from 'class-validator';
+
+export class UpdateUserChoiceWithAiRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  position: number;
+
+  @IsString()
+  content: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isCorrect: boolean;
+}

--- a/packages/server/src/module/quiz/presentation/dto/response/create-chioce-with-ai.response.dto.ts
+++ b/packages/server/src/module/quiz/presentation/dto/response/create-chioce-with-ai.response.dto.ts
@@ -1,13 +1,13 @@
 import { IsArray, ValidateNested } from 'class-validator';
-import { CreateChoiceResponseDto } from './create-choice.response.dto';
 import { Expose, plainToInstance, Type } from 'class-transformer';
+import { UpdateChoiceWithAiResponseDto } from './update-user-choice-with-ai.response.dto';
 
 export class CreateChoiceWithAiResponseDto {
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => CreateChoiceResponseDto)
+  @Type(() => UpdateChoiceWithAiResponseDto)
   @Expose()
-  choices: CreateChoiceResponseDto[];
+  choices: UpdateChoiceWithAiResponseDto[];
 
   static fromAiChoice(quiz: any): CreateChoiceWithAiResponseDto {
     return plainToInstance(CreateChoiceWithAiResponseDto, quiz, {

--- a/packages/server/src/module/quiz/presentation/dto/response/update-user-choice-with-ai.response.dto.ts
+++ b/packages/server/src/module/quiz/presentation/dto/response/update-user-choice-with-ai.response.dto.ts
@@ -1,0 +1,26 @@
+import { Expose } from 'class-transformer';
+import { IsNotEmpty, IsString, IsBoolean, IsNumber } from 'class-validator';
+
+export class UpdateChoiceWithAiResponseDto {
+  @IsString()
+  @Expose()
+  content: string;
+
+  @IsBoolean()
+  @IsNotEmpty()
+  @Expose()
+  isCorrect: boolean;
+
+  @IsNumber()
+  @IsNotEmpty()
+  @Expose()
+  position: number;
+
+  static fromAiChoice(choice: any): UpdateChoiceWithAiResponseDto {
+    return {
+      content: choice.content,
+      isCorrect: choice.isCorrect,
+      position: choice.position,
+    };
+  }
+}

--- a/packages/server/src/module/quiz/presentation/quiz.controller.ts
+++ b/packages/server/src/module/quiz/presentation/quiz.controller.ts
@@ -21,8 +21,8 @@ import { UpdateClassRequestDto } from './dto/request/update-class.request.dto';
 import { UpdateQuizListRequestDto } from './dto/request/update-quizlist.request.dto';
 import { CreateQuizWithAiDto } from './dto/request/create-quiz-with-ai.request.dto';
 import { CreateQuizWithAiResponseDto } from './dto/response/create-quiz-with-ai.response.dto';
-import { CreateChoiceWithAiDto } from './dto/request/create-choice-with-ai.request.dto';
 import { CreateChoiceWithAiResponseDto } from './dto/response/create-chioce-with-ai.response.dto';
+import { CreateChoiceWithAiDto } from './dto/request/create-choice-with-ai.request.dto';
 
 @Controller('api')
 export class QuizController {


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용
- 빈 문자열의 선택지도 허용 가능합니다.
### 스크린샷
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/1cba4e38-7fa9-431f-8c6d-c6d574ee6fb0" />

## 💬리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
## 참고 자료
